### PR TITLE
Update names of festivals and Edinburgh Festivals Listings API

### DIFF
--- a/11-word-freq.Rmd
+++ b/11-word-freq.Rmd
@@ -11,11 +11,9 @@ In this tutorial, you will learn how to summarise, aggregate, and analyze text i
 
 ## Setup 
 
-To practice these skills, we will use a dataset that I have already collected from the Edinburgh Fringe Festival website. 
+To practice these skills, we will use a dataset that I have already collected from the Edinburgh Festivals Listings API.  The API provides open access to the listings of Edinburgh's 11 major festivals, including the data for the Edinburgh International Book Festival which we will be using.
 
-You can try this out yourself too: to obtain these data, you must first obtain an API key. Instructions on how to do this are available at the [Edinburgh Fringe API page](https://api.edinburghfestivalcity.com/documentation/fringe_approval):
-
-![Alt Text](data/wordfreq/fringeapi.png)
+You can try this out yourself too: to obtain these data, you must first obtain a free API key. You can do this by [registering for an account on the Edinburgh Festivals Listings API](https://api.edinburghfestivalcity.com/login).
 
 ##  Load data and packages 
 
@@ -29,7 +27,7 @@ library(readr) # more informative and easy way to import data
 library(babynames) #for gender predictions
 ```
 
-For this tutorial, we will be using data that I have pre-cleaned and provided in .csv format. The data come from the Edinburgh Book Festival API, and provide data for every event that has taken place at the Edinburgh Book Festival, which runs every year in the month of August, for nine years: 2012-2020. There are many questions we might ask of these data. In this tutorial, we will investigate the contents of each event, and the speakers at each event, to determine if there are any trends in gender representation over time.
+For this tutorial, we will be using data that I have pre-cleaned and provided in .csv format. The data come from the Edinburgh Festivals Listings API, and provide data for every event that has taken place at the Edinburgh International Book Festival, which runs every year in the month of August, for nine years: 2012-2020. There are many questions we might ask of these data. In this tutorial, we will investigate the contents of each event, and the speakers at each event, to determine if there are any trends in gender representation over time.
 
 The first task, then, is to read in these data. We can do this with the `read_csv()` function.
 
@@ -39,7 +37,7 @@ The `read_csv()` function takes the .csv file and loads it into the working envi
 edbfdata <- read_csv("data/wordfreq/edbookfestall.csv")
 ```
 
-If you're working on this document from your own computer ("locally") you can download the Edinburgh Fringe data in the following way:
+If you're working on this document from your own computer ("locally") you can download the Book Festival data in the following way:
 
 ```{r, eval = F}
 edbfdata <- read_csv("https://raw.githubusercontent.com/cjbarrie/RDL-Ed/main/02-text-as-data/data/edbookfestall.csv")
@@ -107,13 +105,13 @@ tidy_des <- evdes %>%
 
 ```
 
-## Back to the Fringe
+## Back to the Book Festival
 
 We see that the resulting dataset is large (~446k rows). This is because the above commands have first taken the events text, and has "mutated" it into a set of lower case character string. With the "unnest_tokens" function it has then taken each individual string and create a new column called "word" that contains each individual word contained in the event description texts.
 
 Some terminology is also appropriate here. When we tidy our text into this format, we often refer to these data structures as consisting of "documents" and "terms." This is because by "tokenizing" our text with the "unnest_tokens" functions we are generating a dataset with one term per row. 
 
-Here, our "documents" are the collection of descriptions for all events in each year at the Edinburgh Book Festival. The way in which we sort our text into "documents" depends on the choice of the individual researcher. 
+Here, our "documents" are the collection of descriptions for all events in each year at the Edinburgh International Book Festival. The way in which we sort our text into "documents" depends on the choice of the individual researcher.
 
 Instead of by year, we might have wanted to sort our text into "genre." Here, we have two genres: "Literature" and "Children." Had we done so, we would then have only two "documents," which contained all of the words included in the event descriptions for each genre. 
 
@@ -286,7 +284,7 @@ You don't necessarily have to follow each step of how I have done this---I inclu
 
 The <tt>babynames</tt> package. contains, for each year, the number of children born with a given name, as well as their sex. With this information, we can then calculate the total number of individuals with a given name born for each sex in a given year. 
 
-Given we also have the total number of babies born in total cross these records, we can denominate (divide) the sums for each name by the total number of births for each sex in each year. We can take this proportion as representing the probability that a given individual in our Edinburgh Fringe dataset is male or female. 
+Given we also have the total number of babies born in total cross these records, we can denominate (divide) the sums for each name by the total number of births for each sex in each year. We can take this proportion as representing the probability that a given individual in our Book Festival dataset is male or female.
 
 More information on the <tt>babynames</tt> package can be found [here](https://www.ssa.gov/oact/babynames/limits.html). 
 
@@ -345,7 +343,7 @@ head(totprops)
 
 ```
 
-Once we have our proportions for all names, we can then merge these back with the names of our artists from the Edinburgh Fringe Book Festival. We can then easily plot the proportion of artists at the Festival who are male versus female in each year of the Festival. 
+Once we have our proportions for all names, we can then merge these back with the names of our artists from the Edinburgh International Book Festival. We can then easily plot the proportion of artists at the Festival who are male versus female in each year of the Festival.
 
 ```{r}
 
@@ -364,7 +362,7 @@ ggplot(ednameprops, aes(x=year, fill = factor(sex))) +
 
 What can we conclude form this graph?
 
-Note that when we merged the proportions from th "babynames" data with our Edinburgh Fringe data we lost some observations. This is because some names in the Edinburgh Fringe data had no match in the "babynames" data. Let's look at the names that had no match:
+Note that when we merged the proportions from the "babynames" data with our Book Festival data we lost some observations. This is because some names in the Book Festival data had no match in the "babynames" data. Let's look at the names that had no match:
 
 ```{r}
 names1 <- ednameprops$name

--- a/11-word-freq.knit.md
+++ b/11-word-freq.knit.md
@@ -11,73 +11,10 @@ In this tutorial, you will learn how to summarise, aggregate, and analyze text i
 
 ## Setup 
 
-To practice these skills, we will use a dataset that I have already collected from the Edinburgh Fringe Festival website. 
+To practice these skills, we will use a dataset that I have already collected from the Edinburgh Festivals Listings API.  The API provides open access to the listings of Edinburgh's 11 major festivals, including the data for the Edinburgh International Book Festival which we will be using. 
 
-You can try this out yourself too: to obtain these data, you must first obtain an API key. Instructions on how to do this are available at the [Edinburgh Fringe API page](https://api.edinburghfestivalcity.com/documentation/fringe_approval):
-
-![Alt Text](data/wordfreq/fringeapi.png)
+You can try this out yourself too: to obtain these data, you must first obtain a free API key. You can do this by [registering for an account on the Edinburgh Festivals Listings API](https://api.edinburghfestivalcity.com/login).
 
 ##  Load data and packages 
 
 Before proceeding, we'll load the remaining packages we will need for this tutorial.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/12-sent-analysis.Rmd
+++ b/12-sent-analysis.Rmd
@@ -13,7 +13,7 @@ In this tutorial, you will learn how to:
 
 ## Setup 
 
-The hands-on exercise for this week uses dictionary-based methods for filtering and scoring words. Dictionary-based methods use pre-generated lexicons, which are no more than list of words with associated scores or variables measuring the valence of a particular word. In this sense, the exercise is not unlike our analysis of Edinburgh Book Festival event descriptions. Here, we were filtering descriptions based on the presence or absence of a word related to women or gender. We can understand this approach as a particularly simple type of "dictionary-based" method. Here, our "dictionary" or "lexicon" contained just a few words related to gender. 
+The hands-on exercise for this week uses dictionary-based methods for filtering and scoring words. Dictionary-based methods use pre-generated lexicons, which are no more than list of words with associated scores or variables measuring the valence of a particular word. In this sense, the exercise is not unlike our analysis of Edinburgh International Book Festival event descriptions. Here, we were filtering descriptions based on the presence or absence of a word related to women or gender. We can understand this approach as a particularly simple type of "dictionary-based" method. Here, our "dictionary" or "lexicon" contained just a few words related to gender.
 
 ##  Load data and packages 
 

--- a/19-validation.Rmd
+++ b/19-validation.Rmd
@@ -45,7 +45,7 @@ We'll first read in this data.
 edbfdata <- read_csv("data/wordfreq/edbookfestall.csv")
 ```
 
-As ever, if you're working on this document from your own computer ("locally") you can download the Edinburgh Fringe data in the following way:
+As ever, if you're working on this document from your own computer ("locally") you can download the Book Festival data in the following way:
 
 ```{r, eval = F}
 edbfdata <- read_csv("https://raw.githubusercontent.com/cjbarrie/RDL-Ed/main/02-text-as-data/data/edbookfestall.csv")

--- a/docs/exercise-1-word-frequency-analysis.html
+++ b/docs/exercise-1-word-frequency-analysis.html
@@ -126,8 +126,8 @@
 <h2>
 <span class="header-section-number">17.2</span> Setup<a class="anchor" aria-label="anchor" href="#setup-6"><i class="fas fa-link"></i></a>
 </h2>
-<p>To practice these skills, we will use a dataset that I have already collected from the Edinburgh Fringe Festival website.</p>
-<p>You can try this out yourself too: to obtain these data, you must first obtain an API key. Instructions on how to do this are available at the <a href="https://api.edinburghfestivalcity.com/documentation/fringe_approval">Edinburgh Fringe API page</a>:</p>
+<p>To practice these skills, we will use a dataset that I have already collected from the Edinburgh Festivals Listings API.  The API provides open access to the listings of Edinburgh's 11 major festivals, including the data for the Edinburgh International Book Festival which we will be using.</p>
+    <p>You can try this out yourself too: to obtain these data, you must first obtain a free API key. You can do this by <a href="https://api.edinburghfestivalcity.com/login">registering for an account on the Edinburgh Festivals Listings API</a>.</p>
 <div class="float">
 <img src="data/wordfreq/fringeapi.png" alt="Alt Text"><div class="figcaption">Alt Text</div>
 </div>
@@ -157,7 +157,7 @@
 ## ℹ Use `spec()` to retrieve the full column specification for this data. ℹ
 ## Specify the column types or set `show_col_types = FALSE` to quiet this message.
 ## • `` -&gt; `...1`</code></pre>
-<p>If you’re working on this document from your own computer (“locally”) you can download the Edinburgh Fringe data in the following way:</p>
+<p>If you're working on this document from your own computer ("locally") you can download the Book Festival data in the following way:</p>
 <div class="sourceCode" id="cb172"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="va">edbfdata</span> <span class="op">&lt;-</span> <span class="fu"><a href="https://readr.tidyverse.org/reference/read_delim.html">read_csv</a></span><span class="op">(</span><span class="st">"https://raw.githubusercontent.com/cjbarrie/RDL-Ed/main/02-text-as-data/data/edbookfestall.csv"</span><span class="op">)</span></span></code></pre></div>
 </div>
@@ -235,7 +235,7 @@
 </div>
 <div id="back-to-the-fringe" class="section level2" number="17.6">
 <h2>
-<span class="header-section-number">17.6</span> Back to the Fringe<a class="anchor" aria-label="anchor" href="#back-to-the-fringe"><i class="fas fa-link"></i></a>
+<span class="header-section-number">17.6</span> Back to the Book Festival<a class="anchor" aria-label="anchor" href="#back-to-the-fringe"><i class="fas fa-link"></i></a>
 </h2>
 <p>We see that the resulting dataset is large (~446k rows). This is because the above commands have first taken the events text, and has “mutated” it into a set of lower case character string. With the “unnest_tokens” function it has then taken each individual string and create a new column called “word” that contains each individual word contained in the event description texts.</p>
 <p>Some terminology is also appropriate here. When we tidy our text into this format, we often refer to these data structures as consisting of “documents” and “terms.” This is because by “tokenizing” our text with the “unnest_tokens” functions we are generating a dataset with one term per row.</p>
@@ -437,7 +437,7 @@
 <p>Unfortunately, this package no longer works with newer versions of R; fortunately, I have recreated it using the original “babynames” data, which comes bundled in the <tt>babynames</tt> package.</p>
 <p>You don’t necessarily have to follow each step of how I have done this—I include this information for the sake of completeness.</p>
 <p>The <tt>babynames</tt> package. contains, for each year, the number of children born with a given name, as well as their sex. With this information, we can then calculate the total number of individuals with a given name born for each sex in a given year.</p>
-<p>Given we also have the total number of babies born in total cross these records, we can denominate (divide) the sums for each name by the total number of births for each sex in each year. We can take this proportion as representing the probability that a given individual in our Edinburgh Fringe dataset is male or female.</p>
+<p>Given we also have the total number of babies born in total cross these records, we can denominate (divide) the sums for each name by the total number of births for each sex in each year. We can take this proportion as representing the probability that a given individual in our Book Festival dataset is male or female.</p>
 <p>More information on the <tt>babynames</tt> package can be found <a href="https://www.ssa.gov/oact/babynames/limits.html">here</a>.</p>
 <p>We first load the babynames package into the R environment as a data.frame object. Because the data.frame “babynames” is contained in the <tt>babynames</tt> package we can just call it as an object and store it with .</p>
 <p>This dataset contains names for all years over a period 1800–2019. The variable “n” represents the number of babies born with the given name and sex in that year, and the “prop” represents, according to the package materials accessible <a href="https://cran.r-project.org/web/packages/babynames/babynames.pdf">here</a>, “n divided by total number of applicants in that year, which means proportions are of people of that gender with that name born in that year.”</p>
@@ -503,7 +503,7 @@
 ## 4 Aabir         1      5 M    
 ## 5 Aabriella     1      5 F    
 ## 6 Aada          1      5 F</code></pre>
-<p>Once we have our proportions for all names, we can then merge these back with the names of our artists from the Edinburgh Fringe Book Festival. We can then easily plot the proportion of artists at the Festival who are male versus female in each year of the Festival.</p>
+<p>Once we have our proportions for all names, we can then merge these back with the names of our artists from the Edinburgh International Book Festival. We can then easily plot the proportion of artists at the Festival who are male versus female in each year of the Festival.</p>
 <div class="sourceCode" id="cb210"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="va">ednameprops</span> <span class="op">&lt;-</span> <span class="fu"><a href="https://rdrr.io/r/base/merge.html">merge</a></span><span class="op">(</span><span class="va">totprops</span>, <span class="va">gendes</span>, by <span class="op">=</span> <span class="st">"name"</span><span class="op">)</span></span>
 <span></span>
@@ -517,7 +517,7 @@
 <span>  <span class="fu"><a href="https://ggplot2.tidyverse.org/reference/geom_abline.html">geom_abline</a></span><span class="op">(</span>slope<span class="op">=</span><span class="fl">0</span>, intercept<span class="op">=</span><span class="fl">0.5</span>,  col <span class="op">=</span> <span class="st">"black"</span>,lty<span class="op">=</span><span class="fl">2</span><span class="op">)</span></span></code></pre></div>
 <div class="inline-figure"><img src="main_files/figure-html/unnamed-chunk-109-1.png" width="672"></div>
 <p>What can we conclude form this graph?</p>
-<p>Note that when we merged the proportions from th “babynames” data with our Edinburgh Fringe data we lost some observations. This is because some names in the Edinburgh Fringe data had no match in the “babynames” data. Let’s look at the names that had no match:</p>
+<p>Note that when we merged the proportions from th “babynames” data with our Book Festival data we lost some observations. This is because some names in the Book Festival data had no match in the “babynames” data. Let’s look at the names that had no match:</p>
 <div class="sourceCode" id="cb211"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="va">names1</span> <span class="op">&lt;-</span> <span class="va">ednameprops</span><span class="op">$</span><span class="va">name</span></span>
 <span><span class="va">names2</span> <span class="op">&lt;-</span> <span class="va">gendes</span><span class="op">$</span><span class="va">name</span></span>
@@ -598,7 +598,7 @@
 <li><a class="nav-link" href="#load-data-and-packages"><span class="header-section-number">17.3</span> Load data and packages</a></li>
 <li><a class="nav-link" href="#inspect-and-filter-data"><span class="header-section-number">17.4</span> Inspect and filter data</a></li>
 <li><a class="nav-link" href="#tidy-the-text"><span class="header-section-number">17.5</span> Tidy the text</a></li>
-<li><a class="nav-link" href="#back-to-the-fringe"><span class="header-section-number">17.6</span> Back to the Fringe</a></li>
+<li><a class="nav-link" href="#back-to-the-fringe"><span class="header-section-number">17.6</span> Back to the Book Festival</a></li>
 <li><a class="nav-link" href="#analyze-keywords"><span class="header-section-number">17.7</span> Analyze keywords</a></li>
 <li><a class="nav-link" href="#compute-aggregate-statistics"><span class="header-section-number">17.8</span> Compute aggregate statistics</a></li>
 <li><a class="nav-link" href="#plot-time-trends"><span class="header-section-number">17.9</span> Plot time trends</a></li>

--- a/docs/exercise-7-sampling-text-information-1.html
+++ b/docs/exercise-7-sampling-text-information-1.html
@@ -97,7 +97,7 @@
 ## 
 ## ℹ Use `spec()` to retrieve the full column specification for this data.
 ## ℹ Specify the column types or set `show_col_types = FALSE` to quiet this message.</code></pre>
-<p>As ever, if you’re working on this document from your own computer (“locally”) you can download the Edinburgh Fringe data in the following way:</p>
+<p>As ever, if you’re working on this document from your own computer (“locally”) you can download the Book Festival data in the following way:</p>
 <div class="sourceCode" id="cb5"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb5-1"><a href="exercise-7-sampling-text-information-1.html#cb5-1" aria-hidden="true" tabindex="-1"></a>edbfdata <span class="ot">&lt;-</span> <span class="fu">read_csv</span>(<span class="st">"https://github.com/cjbarrie/CTA-ED/blob/main/data/wordfreq/edbookfestall.csv"</span></span></code></pre></div>
 <p>We’ll get the data into tidy format as before, tagging individual words for whether or not they appear in our dictionary of woman- and gender-related terms. One addition here is that we’re ascribing each event an individual ID, which will be useful in the next step.</p>
 <div class="sourceCode" id="cb6"><pre class="downlit sourceCode r">

--- a/docs/exercise-9-validation.html
+++ b/docs/exercise-9-validation.html
@@ -157,7 +157,7 @@
 ## ℹ Use `spec()` to retrieve the full column specification for this data. ℹ
 ## Specify the column types or set `show_col_types = FALSE` to quiet this message.
 ## • `` -&gt; `...1`</code></pre>
-<p>As ever, if you’re working on this document from your own computer (“locally”) you can download the Edinburgh Fringe data in the following way:</p>
+<p>As ever, if you’re working on this document from your own computer (“locally”) you can download the Book Festival data in the following way:</p>
 <div class="sourceCode" id="cb442"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="va">edbfdata</span> <span class="op">&lt;-</span> <span class="fu"><a href="https://readr.tidyverse.org/reference/read_delim.html">read_csv</a></span><span class="op">(</span><span class="st">"https://raw.githubusercontent.com/cjbarrie/RDL-Ed/main/02-text-as-data/data/edbookfestall.csv"</span><span class="op">)</span></span></code></pre></div>
 <p>We’ll get the data into tidy format as before, tagging individual words for whether or not they appear in our dictionary of woman- and gender-related terms. One addition here is that we’re ascribing each event an individual ID, which will be useful in the next step.</p>

--- a/docs/slides/01-word-freq-pres.Rpres
+++ b/docs/slides/01-word-freq-pres.Rpres
@@ -76,7 +76,7 @@ bookdata %>%
 ![](images/mildigbooksfreq.png)
 </center>
 
-Running Your First Analysis: Edinburgh Book Festival
+Running Your First Analysis: Edinburgh International Book Festival
 ========================================================
 ```{r, eval=TRUE}
 library(tidyverse) # loads dplyr, ggplot2, and others
@@ -157,7 +157,7 @@ Check out:
 3. R4DS [chapter 14](https://r4ds.had.co.nz/strings.html#matching-patterns-with-regular-expressions)
 
 
-Back to the Fringe: computing counts
+Back to the Book Festival: computing counts
 ========================================================
 ```{r, message=FALSE, warning=FALSE, eval=TRUE}
 tidy_des %>%

--- a/docs/slides/01-word-freq-pres.html
+++ b/docs/slides/01-word-freq-pres.html
@@ -924,7 +924,7 @@ bookdata &lt;- tibble(txt = prideprejudice)
 
 </section>
 <section data-transition="none" data-transition-speed="default">
-<h3>Running Your First Analysis: Edinburgh Book Festival</h3>
+<h3>Running Your First Analysis: Edinburgh International Book Festival</h3>
 <div class="slideContent" >
 <pre><code class="r">library(tidyverse) # loads dplyr, ggplot2, and others
 library(tidytext) # includes set of functions useful for manipulating text
@@ -1071,7 +1071,7 @@ str_detect(x, &quot;\\d+&quot;)
 
 </section>
 <section data-transition="none" data-transition-speed="default">
-<h3>Back to the Fringe: computing counts</h3>
+<h3>Back to the Book Festival: computing counts</h3>
 <div class="slideContent" >
 <pre><code class="r">tidy_des %&gt;%
   count(word, sort = TRUE) %&gt;%

--- a/docs/slides/01-word-freq-pres.md
+++ b/docs/slides/01-word-freq-pres.md
@@ -118,7 +118,7 @@ bookdata %>%
 ![](images/mildigbooksfreq.png)
 </center>
 
-Running Your First Analysis: Edinburgh Book Festival
+Running Your First Analysis: Edinburgh International Book Festival
 ========================================================
 
 ```r
@@ -260,7 +260,7 @@ Check out:
 3. R4DS [chapter 14](https://r4ds.had.co.nz/strings.html#matching-patterns-with-regular-expressions)
 
 
-Back to the Fringe: computing counts
+Back to the Book Festival: computing counts
 ========================================================
 
 ```r


### PR DESCRIPTION
Hi @MarionLieutaud,

I'm one of the team that looks after the Edinburgh Festivals Listings API. We're delighted to see that you're using our data in the Computational Text Analysis course!

We recently had an application from one of your students to access the Edinburgh Festival Fringe data through the API to complete these modules. I noticed that although various parts of the course refer to Fringe data, it's not actually using that. As far as I can see all the data you're using is from the Edinburgh International Book Festival, which is freely available to anyone who registers for an API key.

I've therefore proposed a few changes to update the festivals to their correct names, and clarify the instructions for accessing the source data directly.

Unfortunately I'm not familiar with bookdown and had trouble getting it to re-render the compiled files (it was hitting various package / library errors). So I've included a second commit that manually patches my changes onto the compiled files - but appreciate you may prefer to just rebuild those.

Thanks,
Andrew

